### PR TITLE
6 dbms별 sql 차이를 반영한 few shot prompt 최적화 제안

### DIFF
--- a/interface/streamlit_app.py
+++ b/interface/streamlit_app.py
@@ -44,6 +44,8 @@ if st.button("쿼리 실행"):
 
     # 결과 출력
     st.write("총 토큰 사용량:", total_tokens)
-    st.write("결과:", res["generated_query"].content)
+    # st.write("결과:", res["generated_query"].content)
+    st.write("결과:", "\n\n```sql\n" + res["generated_query"] + "\n```")
+    st.write("결과 설명:\n\n", res["messages"][-1].content)
     st.write("AI가 재해석한 사용자 질문:\n", res["refined_input"].content)
     st.write("참고한 테이블 목록:", res["searched_tables"])

--- a/interface/streamlit_app.py
+++ b/interface/streamlit_app.py
@@ -1,6 +1,7 @@
 import streamlit as st
 from langchain_core.messages import HumanMessage
 from llm_utils.graph import builder
+from langchain.chains.sql_database.prompt import SQL_PROMPTS
 
 # Streamlit 앱 제목
 st.title("Lang2SQL")
@@ -11,9 +12,10 @@ user_query = st.text_area(
     value="고객 데이터를 기반으로 유니크한 유저 수를 카운트하는 쿼리",
 )
 
-user_database_env = st.text_area(
+user_database_env = st.selectbox(
     "db 환경정보를 입력하세요:",
-    value="duckdb",
+    options=SQL_PROMPTS.keys(),
+    index=0,
 )
 
 

--- a/llm_utils/llm_factory.py
+++ b/llm_utils/llm_factory.py
@@ -17,7 +17,7 @@ def get_llm(
     if model_type == "openai":
         return ChatOpenAI(
             model=model_name,
-            openai_api_key=openai_api_key,
+            api_key=openai_api_key,
             **kwargs,
         )
 


### PR DESCRIPTION
[이슈](https://github.com/CausalInferenceLab/Lang2SQL/issues/6#issuecomment-2709907899)에서 제안 주신 langchain에 built-in 되어 있는 `SQL_PROMPTS`를 사용하여 각자 다른 DB 환경에 맞게 SQL를 생성하도록 하였습니다.

Update 항목
- `llm_utils/graph.py` - `query_maker_node`와 같은 역할을 하는 `query_maker_node_with_db_guide`를 만들었습니다. 
- `llm_utils/graph.py` - SQL result를 `SQLResult`를 pydantic으로 정의하여 sql와 sql의 설명을 받도록 하여 sql에 불필요한 정보가 담기지 않고 sql의 설명을 이용하여 reasoning을 받아 사용자에게 설명하도록 하였습니다. 
- `interface/streamlit_app.py` - graph의 response가 변경되어 streamlit의 출력 부분을 업데이트 하였습니다.
- `interface/streamlit_app.py` - streamlit 상에서 `user_database_env`를 받는 방법을 `selectbox`로 변경하였습니다.