### PR TITLE
requirements.txt를 setup.py에서 읽어서 사용

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,40 +1,49 @@
-# setup.py
+"""
+setup.py - lang2sql 패키지의 설치 및 배포 구성을 정의하는 파일입니다.
+
+이 파일은 setuptools를 사용하여 패키지 메타데이터, 의존성, CLI 엔트리 포인트 등을 지정하며,
+pip 또는 Python 배포 도구들이 이 정보를 바탕으로 설치를 수행합니다.
+"""
+
 from setuptools import find_packages, setup
+
+
+def load_requirements(path="requirements.txt"):
+    """
+    주어진 경로의 requirements.txt 파일을 읽어 의존성 목록을 반환합니다.
+
+    각 줄을 읽고, 빈 줄이나 주석(#)은 무시합니다.
+
+    Args:
+        path (str): 읽을 requirements 파일 경로 (기본값: 'requirements.txt')
+
+    Returns:
+        list[str]: 설치할 패키지 목록
+    """
+
+    with open(path, "r", encoding="utf-8") as f:
+        return [line.strip() for line in f if line.strip() and not line.startswith("#")]
+
+
+requirements = load_requirements()
 
 with open("docs/README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    name="lang2sql",  # 패키지 이름
-    version="0.1.9",  # 버전
+    name="lang2sql",
+    version="0.1.9",
     author="ehddnr301",
     author_email="dy95032@gmail.com",
     url="https://github.com/CausalInferenceLab/Lang2SQL",
     description="Lang2SQL - Query Generator for Data Warehouse",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=find_packages(),  # my_package를 자동으로 찾음
-    install_requires=[
-        "langgraph==0.2.62",
-        "datahub==0.999.1",
-        "langchain==0.3.14",
-        "langchain-community==0.3.14",
-        "openai==1.59.8",
-        "langchain-openai==0.3.0",
-        "streamlit==1.41.1",
-        "python-dotenv==1.0.1",
-        "faiss-cpu==1.10.0",
-        "langchain-aws>=0.2.21,<0.3.0",
-        "langchain-google-genai>=2.1.3,<3.0.0",
-        "langchain-ollama>=0.3.2,<0.4.0",
-        "langchain-huggingface>=0.1.2,<0.2.0",
-        "transformers==4.51.2",
-        "pytest>=8.3.5",
-    ],
+    packages=find_packages(),
+    install_requires=requirements,
     entry_points={
         "console_scripts": [
-            # "my-project" 명령어로 my_package.main 모듈의 run 함수를 실행
-            "lang2sql = cli.__init__:cli"
-        ]
+            "lang2sql = cli.__init__:cli",
+        ],
     },
 )


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- ex) #이슈번호, #이슈번호 -->
- #110 

## 📝 요약(Summary)
<!-- 해당 PR에 대해서 간단히 설명해주세요(3줄 이내). (Why? How?) -->
<!-- (세부적인 내용은 Issue에 작성되었을 것이라고 가정합니다) -->
작업 내용
현재는 파이썬 라이브러리를 requirements.txt, setup.py 두 곳에서 관리함.
requirements.txt만 관리하고, setup.py는 requirements.txt를 읽어서 사용하도록 수정

장점

의존성 정의의 중복 방지
setup.py와 requirements.txt에 각각 같은 패키지를 따로 관리하면, 버전 충돌, 누락 또는 중복, 설치 실패 등의 문제가 발생할 수 있음.

하나의 소스 오브 트루스(Source of Truth) 유지
패키지를 설치할 때는 requirements.txt를, 배포할 때는 setup.py를 참조하게 되면 관리 포인트가 2배가 됨.
한 곳만 수정하고 나머지는 깜빡하면 버그로 이어질 수 있음.

CI/CD 자동화에 유리
자동 테스트, 릴리스, Docker 이미지 빌드 등에서 일관된 의존성 관리가 필요함
pip install .과 pip install -r requirements.txt가 동일한 환경을 보장해야 예측 가능한 배포가 가능해짐.

## 💬  To Reviewers (선택)
<!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 작성해주세요. --> 
<!-- ex) 특정 코드의 분기를 처리함에 있어서 적절한 방법일 지 확인 부탁드립니다. -->
- None

## PR Checklist
<!-- [ ] 변경 사항에 대한 테스트 (버그 수정 or 기능에 대한 테스트) -->
- `pip install .`


## reference) How to Code Review
- 따봉(👍): 리뷰어가 리뷰이의 코드에서 칭찬의 의견을 남기고 싶을 때 사용합니다.
- 느낌표(❗): 리뷰어가 리뷰이에게 필수적으로 코드 수정을 요청할 때 사용합니다.
- 물음표 (❓): 리뷰어가 리뷰이에게 의견을 물어보고 싶을 때 사용합니다.
- 알약 (💊): 리뷰어가 리뷰이의 코드에서 개선된 방법을 제안하지만 그것의 반영이 필수까지는 아닐 때 사용합니다.