### PR TITLE
feat(catalog): add load_lineage_documents() to DataHubCatalogLoader

### DIFF
--- a/src/lang2sql/core/ports.py
+++ b/src/lang2sql/core/ports.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Protocol, runtime_checkable
 
-from .catalog import TextDocument
+from .catalog import CatalogEntry, TextDocument
 
 
 class LLMPort(Protocol):
@@ -57,3 +57,9 @@ class DocumentLoaderPort(Protocol):
     """Converts a file path or directory to list[TextDocument]."""
 
     def load(self, path: str) -> list[TextDocument]: ...
+
+
+class CatalogLoaderPort(Protocol):
+    """Abstracts catalog loading from external sources (DataHub, file, database, etc.)."""
+
+    def load(self) -> list[CatalogEntry]: ...

--- a/src/lang2sql/integrations/catalog/datahub_.py
+++ b/src/lang2sql/integrations/catalog/datahub_.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from ...core.catalog import CatalogEntry, TextDocument
 from ...core.exceptions import IntegrationMissingError
+from ...core.ports import CatalogLoaderPort
 
 try:
     import datahub as _datahub  # type: ignore[import]
@@ -9,7 +10,7 @@ except ImportError:
     _datahub = None  # type: ignore[assignment]
 
 
-class DataHubCatalogLoader:
+class DataHubCatalogLoader(CatalogLoaderPort):
     """DataHub URN → list[CatalogEntry] 변환.
 
     DataHub GMS 서버에서 테이블 메타데이터를 조회하여


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- ex) #이슈번호, #이슈번호 -->
- TBD

## 📝 요약(Summary)
<!-- 해당 PR에 대해서 간단히 설명해주세요(3줄 이내). (Why? How?) -->
<!-- (세부적인 내용은 Issue에 작성되었을 것이라고 가정합니다) -->
- `DataHubCatalogLoader`에 `load_lineage_documents()` 메서드를 추가하여 DataHub의 테이블·컬럼 단위
lineage를 `TextDocument`로 변환한다.
- `EnrichedNL2SQL`의 `documents` 파라미터에 전달하면 `VectorRetriever`가 lineage 컨텍스트를 인덱싱하여
SQL 생성 시 참조할 수 있다.
- 텍스트 포맷 로직은 `_format_lineage()` 정적 메서드로, URN별 변환은 `_urn_to_lineage_document()`로
분리하여 `load_lineage_documents()`를 단순하게 유지한다.

## 💬  To Reviewers (선택)
<!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 작성해주세요. --> 
<!-- ex) 특정 코드의 분기를 처리함에 있어서 적절한 방법일 지 확인 부탁드립니다. -->
- **사이클 안전성**: lineage 그래프의 사이클 처리는 `DataHubCatalogLoader`에서 별도로 구현하지 않고 하위
 레이어(`get_table_lineage()`의 GraphQL degree 필터, `min_degree_lineage()`의 dict dedup,
`build_table_metadata()`의 self-exclusion)에 위임합니다. 실제 DataHub 환경에서도 충분한지 확인
부탁드립니다.
- **`max_degree` 기본값**: 현재 2로 설정되어 있어 직접 연결(depth 1) + 1단계 확장(depth 2)까지
포함합니다. 실제 그래프 규모에 따라 조회 시간이 길어질 수 있으므로 적절한 기본값인지 의견 부탁드립니다.
- **`CatalogEntry`와의 분리**: lineage는 `CatalogEntry`에 포함하지 않고 `TextDocument`로 분리하여
DataHub 없이도 `CatalogEntry`를 사용할 수 있도록 설계했습니다.

## PR Checklist
<!-- [ ] 변경 사항에 대한 테스트 (버그 수정 or 기능에 대한 테스트) -->
- [ ] 변경 사항에 대한 테스트 (실제 DataHub 연결이 필요하여 unit test 미포함 — integration test로 대체
필요)
- [x] 기존 테스트 전체 통과 확인 (`pytest tests/` — 145 passed, 6 skipped)
- [x] `load_lineage_documents()` docstring에 사용 예시 포함


## reference) How to Code Review
- 따봉(👍): 리뷰어가 리뷰이의 코드에서 칭찬의 의견을 남기고 싶을 때 사용합니다.
- 느낌표(❗): 리뷰어가 리뷰이에게 필수적으로 코드 수정을 요청할 때 사용합니다.
- 물음표 (❓): 리뷰어가 리뷰이에게 의견을 물어보고 싶을 때 사용합니다.
- 알약 (💊): 리뷰어가 리뷰이의 코드에서 개선된 방법을 제안하지만 그것의 반영이 필수까지는 아닐 때 사용합니다.