### PR TITLE
chore: config/, *.db를 .gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,7 @@ ko_reranker_local
 *.csv
 bot.log
 lang2sql_data.db
+*.db
+config/
 lang2sql-datasets/
 docs/lang2sql-datasets.zip


### PR DESCRIPTION
## 📝 요약

로컬 설정 파일과 SQLite DB 파일이 실수로 커밋될 수 있는 상태였습니다.

- `config/` — DB 연결 정보 등 로컬 설정 디렉토리
- `*.db` — SQLite 데이터베이스 파일 (`sample.db` 등)

`lang2sql_data.db`만 제외하고 있던 기존 설정을 `*.db` 패턴으로 확장했습니다.