### PR TITLE
docs: README 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,13 @@ The bot exits loudly if `DISCORD_BOT_TOKEN` is unset. Full setup and hosting:
 ## What V1 does / does NOT do yet (honesty section)
 
 **Does:**
-- 3-scope semantic federation (guild / channel / member) with most-specific-wins
-  resolution; `term_custom` registers definitions per scope (KV-backed).
+- 3-scope semantic federation (org / team / user) — 동일 용어에 여러 레이어 정의가
+  존재하면 현재 채널 정의를 ★ 로 표시하고 전체 주입; LLM이 컨텍스트로 판단.
+  `term_custom` registers definitions per scope (KV-backed);
+  `kind`(metric/table/rule/dimension) · `applies_to` · `tags` 필드 지원.
 - Safety pipeline with the V1 layers (whitelist + timeout), gating every query.
-- Agent loop with eight tools: `run_sql`, `explore_schema`, `enrich_schema`,
-  `term_custom`, `org_setup`, `ingest_doc`, `remember`, `ask_user`.
+- Agent loop with nine tools: `run_sql`, `explore_schema`, `enrich_schema`,
+  `term_custom`, `org_setup`, `ingest_doc`, `confirm_ingest`, `remember`, `ask_user`.
 - Memory service (in-memory store + inject-all recall + manual `/remember`).
 - Discord frontend (bot, commands, session router, render).
 - Encrypted-at-rest secrets (Fernet) and SQLite-backed persistence.
@@ -120,8 +122,8 @@ The bot exits loudly if `DISCORD_BOT_TOKEN` is unset. Full setup and hosting:
   canned `orders`/`users` schema and sample rows; real psycopg execution is v1.5.
 - **Reason without a key.** Without `OPENAI_API_KEY`, the `FakeLLM` returns
   deterministic canned tool cycles — useful for wiring tests, not for answers.
-- DB metadata auto-enrichment, AST-precise SQL validation, function blocklists,
-  cost gating, `/semantic diff` / `/semantic promote`, keyword/vector recall,
+- AST-precise SQL validation, function blocklists, cost gating,
+  `/semantic diff` / `/semantic promote`, keyword/vector recall,
   automatic fact extraction, URL/Notion ingestion — all scoped to v1.5+.
 - Persist across restarts by default: the V1 `SqliteStore` defaults to in-memory;
   point it at a file for durability.
@@ -182,7 +184,7 @@ the [MIT License](https://opensource.org/licenses/MIT). 커뮤니티: [Discord](
 | **AI Engineer** | 김경서 | ![Python](https://img.shields.io/badge/Python-Expert-3776AB) | LLM, FinNLP, FDS, RAG |
 | **Data Engineer** | 홍지영 | ![Python](https://img.shields.io/badge/Python-Expert-3776AB) | LLM, Data Engineering |
 | **Data Operator** | 이화림 | ![Python](https://img.shields.io/badge/Python-Expert-3776AB) | LLM, Data Engineering |
-| **AI Engineer** | 남경혜 | ![Python](https://img.shields.io/badge/Python-Expert-3776AB) | LLM, RAG, Multi-Agent |
+| **AI Engineer** | 조태민 | ![Python](https://img.shields.io/badge/Python-Expert-3776AB) | LLM, RAG, Multi-Agent |
 | **AI Engineer** | 심세원 | ![Python](https://img.shields.io/badge/Python-Expert-3776AB) | LLM, RAG, Multi-Agent |
 | **Business Analyst** | 서희진 | ![Python](https://img.shields.io/badge/Python-Intermediate-FF6C37) | LLM, Data Analysis |
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,12 @@ interface, not the identity** — Slack/Web are adapters on the same core.
 | **③ Hermes memory** | Conversations, facts, and preferences persist instead of resetting each session. |
 | **④ Multi-interface** | Phase 1 Discord today; Slack/Web are future adapters. No platform lock-in. |
 
-## Extensibility — outlets and appliances (콘센트/가전)
+## Extensibility — plug-in extension points
 
-V1 ships the **simplest single implementation** of each extension point, but the
-**abstraction (port) is already in place**, so v1.5/v2 add a new implementation
-*without touching existing code*. Like a wall outlet: the V1 socket has one LED
-bulb plugged in, but because the socket is standard, you later plug in a fan or a
-smart light without rewiring the wall.
+V1 ships the **simplest single implementation** of each extension point, but
+the **abstraction (port) is already in place**, so v1.5/v2 plug in a new
+implementation without touching existing code — like a standard wall outlet
+where you swap the appliance, not the wiring.
 
 Four ★ extension patterns sit behind `core/ports/`:
 
@@ -131,6 +130,8 @@ The bot exits loudly if `DISCORD_BOT_TOKEN` is unset. Full setup and hosting:
 ---
 
 ## Roadmap at a glance
+
+> **Current status: V1 complete** — `enrich_schema` and OKF bundle export are V1.5 features already shipped; next target is AST validation, SQLite file-mode default, and keyword recall.
 
 | Area | V1 | V1.5 | V2 | V2.5 |
 |---|---|---|---|---|

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ interface, not the identity** — Slack/Web are adapters on the same core.
 
 ---
 
-## The four pillars
+## Core capabilities
 
 | Pillar | What it is |
 |---|---|


### PR DESCRIPTION
## Summary

- 시멘틱 스코프 명칭을 `guild/channel/member` → `org/team/user`로 반영 (PR #247 이후 리네임)
- 다중 레이어 정의 주입 방식 설명 추가 — winner-only에서 전체 주입(★ 표시)으로 변경된 동작 반영 (PR #252)
- `term_custom` 도구의 `kind` / `applies_to` / `tags` 필드 추가 반영 (PR #241)
- Agent 도구 수 8 → 9개 (`confirm_ingest` 추가, PR #243/#245)
- "Does NOT yet" 섹션에서 `DB metadata auto-enrichment` 제거 — `enrich_schema`가 V1 toolset에 이미 포함됨
- 팀원 수정

## Test plan

- [ ] README 마크다운 렌더링 확인
- [ ] 코드 변경 없음 — docs only